### PR TITLE
Fix settings.gradle, include Parchment

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,10 @@ pluginManagement {
             name = 'MinecraftForge'
             url = 'https://maven.minecraftforge.net/'
         }
+        maven {
+            name = 'ParchmentMC'
+            url = 'https://maven.parchmentmc.org'
+        }
     }
 }
 


### PR DESCRIPTION
Last commit, whoever made the PR forgot to include Parchment in the settings.gradle. Wouldn't build without it.